### PR TITLE
Fix ucp.flush()

### DIFF
--- a/ucp/comm.py
+++ b/ucp/comm.py
@@ -45,6 +45,11 @@ def tag_send(
     )
 
 
+def flush(worker):
+    return _call_ucx_api(
+        None, worker.flush
+    )
+
 def stream_send(
     ep: ucx_api.UCXEndpoint, buffer, nbytes: int, name="stream_send", event_loop=None
 ) -> asyncio.Future:

--- a/ucp/core.py
+++ b/ucp/core.py
@@ -465,7 +465,7 @@ class ApplicationContext:
         return self.context.mem_map(mem, alloc, fixed)
 
     def flush_worker(self):
-        return self.worker.flush()
+        return comm.flush(self.worker)
 
     def fence_worker(self):
         return self.worker.fence()


### PR DESCRIPTION
This implements the flush functionality we discussed, and eliminates the earlier segfault by passing a valid callback to `ucp_worker_flush_nb`